### PR TITLE
Update SntpClient.cs

### DIFF
--- a/Rhino.Licensing/SntpClient.cs
+++ b/Rhino.Licensing/SntpClient.cs
@@ -53,7 +53,10 @@ namespace Rhino.Licensing
 			index += 1;
 			if (hosts.Length <= index)
 			{
-				failure();
+				if (hosts.Length == index)
+				{
+					failure();
+				}
 				return;
 			}
 			try
@@ -111,7 +114,10 @@ namespace Rhino.Licensing
 			var theState = (State)state;
 			try
 			{
-				theState.Socket.Close();
+				if (theState.Socket != null)
+				{
+					theState.Socket.Close();
+				}
 			}
 			catch (Exception)
 			{


### PR DESCRIPTION
Notify of failures only once.
If no socket has been created then do not try to dispose of it.  This avoids a unnecessary call to BeginGetDate.