### PR TITLE
add ability to validate a license from a string rather than having to save it to a file

### DIFF
--- a/Rhino.Licensing.Tests/License_From_File_And_String_Validate_Correctly.cs
+++ b/Rhino.Licensing.Tests/License_From_File_And_String_Validate_Correctly.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace Rhino.Licensing.Tests
+{
+    public class License_From_File_And_String_Validate_Correctly : BaseLicenseTest
+    {
+        [Fact]
+        public void Will_tell_that_we_are_in_invalid_state()
+        {
+
+            var guid = Guid.NewGuid();
+            var generator = new LicenseGenerator(public_and_private);
+            var expiration = DateTime.Now.AddDays(-30);
+            var key = generator.Generate("Oren Eini", guid, expiration, LicenseType.Trial);
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, key);
+            var validator = new LicenseValidator(public_only, Path.GetTempFileName());
+            Assert.Throws<LicenseNotFoundException>(() => new LicenseValidator(public_only, Path.GetTempFileName()).AssertValidLicense());
+            Assert.Throws<LicenseExpiredException>(() => new LicenseValidator(public_only, null, key).AssertValidLicense());
+        }
+
+        [Fact]
+        public void Will_tell_that_license_can_load_from_file()
+        {
+            var guid = Guid.NewGuid();
+            var generator = new LicenseGenerator(public_and_private);
+            var expiration = DateTime.Now.AddDays(30);
+            var key = generator.Generate("Oren Eini", guid, expiration, LicenseType.Trial);
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, key);
+            new LicenseValidator(public_only, Path.GetTempFileName()).AssertValidLicense();
+        }
+
+        [Fact]
+        public void Will_tell_that_license_can_load_from_string()
+        {
+            var guid = Guid.NewGuid();
+            var generator = new LicenseGenerator(public_and_private);
+            var expiration = DateTime.Now.AddDays(30);
+            var key = generator.Generate("Oren Eini", guid, expiration, LicenseType.Trial);
+            new LicenseValidator(public_only, null, key).AssertValidLicense();
+        }
+    }
+}

--- a/Rhino.Licensing.Tests/Rhino.Licensing.Tests.csproj
+++ b/Rhino.Licensing.Tests/Rhino.Licensing.Tests.csproj
@@ -71,6 +71,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Duplicate_license.cs" />
+    <Compile Include="License_From_File_And_String_Validate_Correctly.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rhino.Licensing.sln
+++ b/Rhino.Licensing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhino.Licensing", "Rhino.Licensing\Rhino.Licensing.csproj", "{05EFD7EB-F0FB-4B65-8E4A-C8FF8DDC6A78}"
 EndProject

--- a/Rhino.Licensing/LicenseValidator.cs
+++ b/Rhino.Licensing/LicenseValidator.cs
@@ -17,10 +17,12 @@ namespace Rhino.Licensing
         /// </summary>
         /// <param name="publicKey">public key</param>
         /// <param name="licensePath">path to license file</param>
-        public LicenseValidator(string publicKey, string licensePath)
+        /// <param name="inMemoryLicense">Optionally set the inMemory license</param>
+        public LicenseValidator(string publicKey, string licensePath, string inMemoryLicense = null)
             : base(publicKey)
         {
             this.licensePath = licensePath;
+            this.inMemoryLicense = inMemoryLicense;
         }
 
         /// <summary>
@@ -49,7 +51,10 @@ namespace Rhino.Licensing
             {
                 try
                 {
-                    File.WriteAllText(licensePath, value);
+                    if (string.IsNullOrEmpty(licensePath))
+                        inMemoryLicense = value;
+                    else
+                        File.WriteAllText(licensePath, value);
                 }
                 catch (Exception e)
                 {
@@ -64,7 +69,7 @@ namespace Rhino.Licensing
         /// </summary>
         public override void AssertValidLicense()
         {
-            if (File.Exists(licensePath) == false)
+            if (!(string.IsNullOrEmpty(licensePath) && !string.IsNullOrEmpty(inMemoryLicense)) && File.Exists(licensePath) == false)
             {
                 Log.WarnFormat("Could not find license file: {0}", licensePath);
                 throw new LicenseFileNotFoundException();
@@ -78,7 +83,8 @@ namespace Rhino.Licensing
         /// </summary>
         public override void RemoveExistingLicense()
         {
-            File.Delete(licensePath);
+            if (!string.IsNullOrEmpty(licensePath))
+                File.Delete(licensePath);
         }
     }
 }


### PR DESCRIPTION
Allow loading a license as a string that may have been saved in a database rather than as an xml file.