### PR TITLE
Fixes #25

### DIFF
--- a/Rhino.Licensing.Tests/Can_use_floating_licenses.cs
+++ b/Rhino.Licensing.Tests/Can_use_floating_licenses.cs
@@ -58,7 +58,7 @@ namespace Rhino.Licensing.Tests
             LicensingService.LicenseServerPrivateKey = floating_private;
 
             var host = new ServiceHost(typeof(LicensingService));
-            var address = "http://localhost:29292/license";
+            var address = "http://localhost:19292/license";
             host.AddServiceEndpoint(typeof(ILicensingService), new WSHttpBinding(), address);
 
             host.Open();


### PR DESCRIPTION
In this one test, port 29292 is used. Assume this is a typo. The test fails when following the readme and using netsh to grant access to 19292. Could have uses netsh to also grant access to 29292 but I am guessing this port was used accidentally so corrected it instead..