### PR TITLE
Provide extension point for overriding default list of time servers

### DIFF
--- a/Rhino.Licensing/AbstractLicenseValidator.cs
+++ b/Rhino.Licensing/AbstractLicenseValidator.cs
@@ -73,7 +73,7 @@ namespace Rhino.Licensing
         {
             get; set;
         }
-
+        
         /// <summary>
         /// Gets the expiration date of the license
         /// </summary>
@@ -396,7 +396,7 @@ namespace Rhino.Licensing
             if (!NetworkInterface.GetIsNetworkAvailable())
                 return;
 
-            var sntp = new SntpClient(TimeServers);
+            var sntp = new SntpClient(GetTimeServers());
             sntp.BeginGetDate(time =>
             {
                 if (time > ExpirationDate)
@@ -406,6 +406,15 @@ namespace Rhino.Licensing
             {
                 /* ignored */
             });
+        }
+
+        /// <summary>
+        /// Extension point to return different time servers
+        /// </summary>
+        /// <returns></returns>
+        protected virtual string[] GetTimeServers()
+        {
+            return TimeServers;
         }
 
         /// <summary>


### PR DESCRIPTION
I was recently notified of unexpected traffic on port 123 in an application I support and tracked the requests to the extended expiration date validation that contacts the hard-coded list of NTP servers in AbstractLicenseValidator. In this pull request, I have added a virtual method that can be used to modify the list of servers by subclasses.